### PR TITLE
Pin Rust 1.26.0 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - libssl-dev
 cache: cargo
 rust:
+  - 1.26.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
This makes it easy to check for changes that accidentally bump the required Rust version.