### PR TITLE
Ensure `debug_assert_match` evals `$value` <= 1 time

### DIFF
--- a/src/parse_macros.rs
+++ b/src/parse_macros.rs
@@ -2,15 +2,16 @@
 macro_rules! debug_assert_match {
     ($pattern:pat, $value:expr) => {
         if cfg!(debug_assertions) {
+            let value = $value;
             #[allow(unreachable_patterns)]
-            match $value {
+            match value {
                 $pattern => {}
                 _ => panic!(
                     "assertion failed: `(value matches pattern)`
  pattern: `{}`,
    value: `{:?}`",
                     stringify!($pattern),
-                    $value
+                    value
                 ),
             }
         }


### PR DESCRIPTION
Otherwise, the error messages can be confusing, e.g. if `$value` is `iter.next()`.